### PR TITLE
Render mermaid code on .language-mermaid

### DIFF
--- a/mermaid-init.js
+++ b/mermaid-init.js
@@ -1,1 +1,1 @@
-mermaid.initialize({startOnLoad:true});
+mermaid.initialize({startOnLoad:true}, document.querySelectorAll(".language-mermaid"));


### PR DESCRIPTION
Based on https://github.com/highlightjs/highlight.js/issues/2212.

I suspect that different versions of mdbook behave differently when producing the HTML code, and that the latest version of mdbook, used in this repository, is not able to render mermaid because it uses a different way to name code block classes.